### PR TITLE
remove copy and enable commands from install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,15 @@ clean:
 	rm $(OUTDIR)/$(OUTFILE)
 	rm $(OUTDIR)/readflow.py
 
+# this command will require root access since it installs bluetooth and python dependencies
+# only works for systems that use apt-get (Ubuntu, Debian, etc).
 install:
 	./install.sh
 
 enable:
+	cp ./suitcontrol.service /etc/systemd/system/suitcontrol.service
 	systemctl enable /etc/systemd/system/suitcontrol.service
 
 disable:
 	systemctl disable /etc/systemd/system/suitcontrol.service
+	rm /etc/systemd/system/suitcontrol.service

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,6 @@ apt-get install libbluetooth-dev
 apt-get install bluez
 
 echo "Install python dependencies"
-apt-get update && apt-get install python-serial python-setuptools python-dev python-smbus python-pip
+apt-get update 
+apt-get install python-serial python-setuptools python-dev python-smbus python-pip
 pip install --upgrade PyBBIO
-
-echo "Setting up suitcontrol service"
-cp ./suitcontrol.service /etc/systemd/system/suitcontrol.service


### PR DESCRIPTION
This pull request will resolve #11 by removing the troublesome copy and enable service commands in the install .sh script. The copy command is then moved to the Make command enable. The disable command was augmented to allow for easier removal of the service. Now when someone is working on the repo on a PC they can run `$make install` without causing problems by adding a service. When someone needs to add a service on the beaglebone they can call `$make enable` to do that. 
