### PR TITLE
Handle Program Exit

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -22,6 +22,23 @@ struct _section {
 static FILE* config_file;
 static struct _section* config_tree;
 
+/*
+	configuration files are in the format
+	[section name1]
+	key1=value1
+	key2=value2
+	[section name2]
+	key1=value1
+	key2=value2
+
+	Ex. 
+	[Bluetooth]
+	android=11:22:33:44:55:6A
+	[automation]
+	temp_warn=28
+	temp_max=32
+*/
+
 static void parse_file() {
 	int c;
 	c = fgetc(config_file);

--- a/include/halosuit/systemstatus.h
+++ b/include/halosuit/systemstatus.h
@@ -5,7 +5,8 @@ typedef enum status {
 	NO_STATUS,
 	BOOT_SUCCESS,
 	BLUETOOTH_CONNECTED,
-	BLUETOOTH_ERROR
+	BLUETOOTH_ERROR,
+	SYSTEM_CRASH = 15
 } status_t;
 
 void systemstatus_init();

--- a/main.c
+++ b/main.c
@@ -12,6 +12,8 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdbool.h>
+#include <signal.h>
+
 
 #include <beagleblue/beagleblue.h>
 #include <json/parser.h>
@@ -30,6 +32,15 @@
 
 bool watchdog_disabled = false;
 
+void crash_signal_handler(int signum) 
+{
+    logger_log("exiting with code: %d", signum);
+
+    systemstatus_set_status(SYSTEM_CRASH);
+
+    exit(signum);
+}
+
 int main(int argc, char* argv[])
 {
     if (argc == 2) {
@@ -47,6 +58,16 @@ int main(int argc, char* argv[])
     }
     logger_startup();
     systemstatus_init();
+
+    // use the bellow link for a good summary of what each signal does
+    // http://www.yolinux.com/TUTORIALS/C++Signals.html
+    signal(SIGINT, crash_signal_handler);
+    signal(SIGABRT, crash_signal_handler);
+    signal(SIGFPE, crash_signal_handler);
+    signal(SIGILL, crash_signal_handler);
+    signal(SIGSEGV, crash_signal_handler);
+    signal(SIGTERM, crash_signal_handler);
+    signal(SIGHUP, crash_signal_handler);
 
     char buf[1024];
     config_init("/root/beaglebone.conf");


### PR DESCRIPTION
Adds signal handlers for all of the handleable crash exit signals.
This patch logs when an exit occurs and changes the system status
to indicate that a potential crash occurred.
